### PR TITLE
Handle additional MC scaling for the limit inputs

### DIFF
--- a/bucoffea/limit/legacy_vbf.py
+++ b/bucoffea/limit/legacy_vbf.py
@@ -197,6 +197,7 @@ def legacy_limit_input_vbf(acc,
     unblind=False, 
     years=[2017, 2018], 
     one_fifth_unblind=False, 
+    mcscales=None,
     ) -> None:
     """
     Writes ROOT TH1 histograms to file as a limit input.
@@ -276,6 +277,11 @@ def legacy_limit_input_vbf(acc,
                     # If we're applying 1/5th unblinding on signal region, down-scale the MC by 0.2
                     if one_fifth_unblind and region == 'sr_vbf_no_veto_all':
                         h_cof.scale(0.2)
+
+                    # If there is additional MC scaling specified via command line, do it here
+                    if mc[region].match(dataset) and region in mcscales:
+                        scale_val = mcscales[region]
+                        h_cof.scale(scale_val)
                     
                     th1 = export_coffea_histogram(h_cof, axname=axname)
                     

--- a/bucoffea/limit/limit.py
+++ b/bucoffea/limit/limit.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 import os
+import csv
 import argparse
 
 from klepto.archives import dir_archive
 from datetime import datetime
+from typing import Dict
+from pprint import pprint
 
 from bucoffea.helpers.git import git_rev_parse, git_diff
 
@@ -18,12 +21,30 @@ def parse_commandline():
     parser.add_argument('--unblind', action='store_true', help='Include signal region data')
     parser.add_argument('--years', nargs='*', default=[2017, 2018], help='The years to prepare the limit input for')
     parser.add_argument('--one_fifth_unblind', action='store_true', help='1/5th unblinding: Scale the MC in signal region by 1/5')
+    parser.add_argument('--mcscales', type=str, default=None, help='An optional txt file for storing the MC scales per region')
     args = parser.parse_args()
 
     if not os.path.isdir(args.inpath):
         raise RuntimeError(f"Commandline argument is not a directory: {args.inpath}")
 
     return args
+
+def get_mc_scales(infile: str) -> Dict[str, float]:
+    """
+    From the given input file containing MC scales per region,
+    write them to a dictionary and return the dict.
+    """
+    scales = {}
+    # If an input file is not provided, just return an empty dict
+    if not infile:
+        return scales
+    
+    with open(infile, 'r') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            scales[row[0]] = float(row[1])
+
+    return scales
 
 def main():
     args = parse_commandline()
@@ -42,6 +63,12 @@ def main():
     except FileExistsError:
         pass
     
+    # Handle MC scaling
+    mcscales = get_mc_scales(args.mcscales)
+    if mcscales:
+        print('Will apply the following MC scaling:')
+        pprint(mcscales)
+
     # Store the command line arguments in the INFO.txt file
     infofile = pjoin(outdir, 'INFO.txt')
     with open(infofile, 'w+') as f:
@@ -72,6 +99,7 @@ def main():
                     unblind=args.unblind, 
                     years=args.years, 
                     one_fifth_unblind=args.one_fifth_unblind,
+                    mcscales=mcscales,
                 )
         else:
             raise ValueError(f'Unknown channel specified: {channel}')


### PR DESCRIPTION
This PR contains updates for the limit input script ,`limit.py`, so that an additional MC scaling can be done via the command line interface, by specifying a CSV file with the scales per region. 