### PR TITLE
Configure default output dir name for bumerge, introduce checks in stack plotting

### DIFF
--- a/bucoffea/plot/studies/stack_plot/plot_data_mc.py
+++ b/bucoffea/plot/studies/stack_plot/plot_data_mc.py
@@ -95,6 +95,9 @@ def commandline():
     return args
 
 def dump_info(args):
+    """
+    Function to dump information about the command line arguments to an INFO.txt file.
+    """
     outdir = pjoin('./output/',list(filter(lambda x:x,args.inpath.split('/')))[-1])
 
     # Store the command line arguments in the INFO.txt file
@@ -105,7 +108,7 @@ def dump_info(args):
     
     infofile = pjoin(outdir, 'INFO.txt')
     with open(infofile, 'w+') as f:
-        f.write(f'Plot script most recently created at: {datetime.now().strftime("%m/%d/%Y, %H:%M:%S")}\n')
+        f.write(f'Plot script run at: {datetime.now().strftime("%m/%d/%Y, %H:%M:%S")}\n')
         f.write('Command line arguments:\n\n')
         cli = vars(args)
         for arg, val in cli.items():

--- a/bucoffea/scripts/bumerge
+++ b/bucoffea/scripts/bumerge
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import argparse
 from bucoffea.helpers.merging import CoffeaMerger
 
@@ -21,20 +22,24 @@ def parse_commandline():
         "--outdir",
         "-o",
         type=str,
-        default="INDIR/merged",
+        default=None,
         help="The output directory to use.",
     )
 
     args = parser.parse_args()
-    if "INDIR" in args.outdir:
-        args.outdir = args.outdir.replace("INDIR", args.indir)
-
+    
+    # Default name of the output directory
+    if not args.outdir:
+        input_dir = os.path.basename(os.path.abspath(args.indir))
+        args.outdir = f'merged_{input_dir}'
 
     return args
 
 
 def main():
     args = parse_commandline()
+    print(f'Merging and saving to output directory: {args.outdir}')
+    
     cm = CoffeaMerger(indir=args.indir, jobs=args.jobs)
     cm.to_klepto_dir(args.outdir)
 


### PR DESCRIPTION
This PR has the following updates:
- `bumerge` will by default save the merged output to a directory named `merged_${input_dir}`
- Checks have been introduced to stack plotting to make sure that data and MC datasets are stored in the histogram object 