### PR TITLE
Update the uncertainty naming scheme for SF uncertainties

### DIFF
--- a/bucoffea/plot/studies/vbf_uncertainties/scale_factors/plot_uncertainties.py
+++ b/bucoffea/plot/studies/vbf_uncertainties/scale_factors/plot_uncertainties.py
@@ -104,7 +104,8 @@ def plot_uncertainty(acc,
         # Save the ratios into an output ROOT file
         ratio = h.integrate("uncertainty", unc).values()[()] / h_nom.values()[()]
 
-        unc_name = f'{nuisance}_up' if 'Up' in unc else f'{nuisance}_down'
+        # Name the uncertainties according to the combine convention
+        unc_name = f'{nuisance}Up' if 'Up' in unc else f'{nuisance}Down'
 
         outputrootfile[f'{dataset_tag}_{unc_name}'] = (ratio, h_nom.axis("score").edges())
 


### PR DESCRIPTION
Due to the convention used by `combine`, the SF uncertainties are renamed to be: `{unc_source}Up` and `{unc_source}Down`.

@pmayenco please note, we can try validating the data cards after replacing the uncertainty ROOT files with this new naming scheme.